### PR TITLE
Fixed picklist deployment error

### DIFF
--- a/force-app/main/custom-metadata-saver/classes/CustomMetadataSaver.cls
+++ b/force-app/main/custom-metadata-saver/classes/CustomMetadataSaver.cls
@@ -66,9 +66,19 @@ public inherited sharing class CustomMetadataSaver {
                 continue;
             }
 
+            Schema.SObjectField field = customMetadataRecord.getSObjectType().getDescribe().fields.getMap().get(fieldName);
+
+            Object value;
+            // Picklist values have to be cast to strings (even though they already look like strings)
+            if (field.getDescribe().getType() == Schema.DisplayType.PICKLIST) {
+                value = String.valueOf(customMetadataRecord.get(field));
+            } else {
+                value = customMetadataRecord.getPopulatedFieldsAsMap().get(fieldName);
+            }
+
             Metadata.CustomMetadataValue customField = new Metadata.CustomMetadataValue();
             customField.field = fieldName;
-            customField.value = customMetadataRecord.getPopulatedFieldsAsMap().get(fieldName);
+            customField.value = value;
             System.debug(LoggingLevel.INFO, 'customField==' + customField);
 
             customMetadata.values.add(customField);

--- a/force-app/main/custom-metadata-saver/classes/CustomMetadataSaver.cls
+++ b/force-app/main/custom-metadata-saver/classes/CustomMetadataSaver.cls
@@ -73,7 +73,7 @@ public inherited sharing class CustomMetadataSaver {
             if (field.getDescribe().getType() == Schema.DisplayType.PICKLIST) {
                 value = String.valueOf(customMetadataRecord.get(field));
             } else {
-                value = customMetadataRecord.getPopulatedFieldsAsMap().get(fieldName);
+                value = customMetadataRecord.get(fieldName);
             }
 
             Metadata.CustomMetadataValue customField = new Metadata.CustomMetadataValue();


### PR DESCRIPTION
Closes #4 - it looks like picklist fields need to be explicitly cast to strings in the code before deploying the custom metadata. 

This is difficult to test in unit tests since Apex will not let you run `Metadata.Operations.enqueueDeployment(deployment, callback);` in a test context (which is where the error occurs). For now, I've manually tested this change in one of my scratch orgs, but I'll look into finding a better way to automatically test this in the future.