### PR TITLE
CustomMetadataSaver now uses an inner class for Flow parameters

### DIFF
--- a/force-app/main/custom-metadata-saver/classes/CustomMetadataSaver.cls
+++ b/force-app/main/custom-metadata-saver/classes/CustomMetadataSaver.cls
@@ -4,8 +4,13 @@
 //----------------------------------------------------------------------------------------------------//
 
 public inherited sharing class CustomMetadataSaver {
-    private static final Set<String> IGNORED_FIELD_NAMES = getIgnoredFieldNames();
     private static final List<String> DEPLOYMENT_JOB_IDS = new List<String>();
+    private static final Set<String> IGNORED_FIELD_NAMES = getIgnoredFieldNames();
+
+    public class FlowInput {
+        @InvocableVariable(required=true label='The collection of custom metadata type records to deploy')
+        public List<SObject> customMetadataRecords;
+    }
 
     private CustomMetadataSaver() {
         //static only
@@ -16,12 +21,12 @@ public inherited sharing class CustomMetadataSaver {
         label='Deploy Changes to Custom Metadata Records'
         description='Deploys changes to the list of custom metadata records'
     )
-    public static void deploy(List<List<SObject>> customMetadataRecordsLists) {
-        System.debug('customMetadataRecordsLists==' + customMetadataRecordsLists);
+    public static void deploy(List<FlowInput> inputs) {
+        System.debug('inputs==' + inputs);
 
         List<SObject> consolidatedList = new List<SObject>();
-        for (List<SObject> customMetadataRecordsList : customMetadataRecordsLists) {
-            consolidatedList.addAll(customMetadataRecordsList);
+        for (FlowInput input : inputs) {
+            consolidatedList.addAll(input.customMetadataRecords);
         }
 
         System.debug('consolidatedList==' + consolidatedList);

--- a/force-app/tests/custom-metadata-saver/classes/CustomMetadataSaver_Tests.cls
+++ b/force-app/tests/custom-metadata-saver/classes/CustomMetadataSaver_Tests.cls
@@ -6,7 +6,7 @@
 @isTest
 private class CustomMetadataSaver_Tests {
     @isTest
-    static void it_should_deploy_cmdt_record() {
+    static void it_should_deploy_cmdt_record_for_list_of_cmdt() {
         CustomMetadataDeployTest__mdt cmdtRecord = new CustomMetadataDeployTest__mdt(
             MasterLabel = 'my test cmdt record',
             DeveloperName = 'my_test_cmdt_record',
@@ -17,6 +17,33 @@ private class CustomMetadataSaver_Tests {
         );
 
         List<CustomMetadataDeployTest__mdt> cdmtRecords = new List<CustomMetadataDeployTest__mdt>{ cmdtRecord };
+
+        System.assertEquals(1, cdmtRecords.size());
+
+        Test.startTest();
+        CustomMetadataSaver.deploy(cdmtRecords);
+        Test.stopTest();
+
+        System.assertEquals(1, CustomMetadataSaver.getDeploymentJobIds().size());
+    }
+
+    @isTest
+    static void it_should_deploy_cmdt_record_for_list_of_flowInputs() {
+        CustomMetadataDeployTest__mdt cmdtRecord = new CustomMetadataDeployTest__mdt(
+            MasterLabel = 'my test cmdt record',
+            DeveloperName = 'my_test_cmdt_record',
+            ExampleCheckboxField__c = true,
+            ExampleDateField__c = System.today(),
+            ExampleDatetimeField__c = System.now(),
+            ExampleTextField__c = 'hello'
+        );
+
+        List<CustomMetadataDeployTest__mdt> cdmtRecords = new List<CustomMetadataDeployTest__mdt>{ cmdtRecord };
+        CustomMetadataSaver.FlowInput input = new CustomMetadataSaver.FlowInput();
+        input.customMetadataRecords = cdmtRecords;
+
+        List<CustomMetadataSaver.FlowInput> inputs = new List<CustomMetadataSaver.FlowInput>();
+        inputs.add(input);
 
         System.assertEquals(1, cdmtRecords.size());
 


### PR DESCRIPTION
Previously, I was using `List<List<SObject>>` as the input from Flow - but this doesn't allow any new properties/attributes to be added (to extend functionality). I've updated `CustomMetadataSaver` to instead use an inner class `FlowInput` as the method parameter.