### PR TITLE
Updated flow deploy method to return the same count as the inputs

### DIFF
--- a/force-app/main/custom-metadata-saver/classes/CustomMetadataSaver.cls
+++ b/force-app/main/custom-metadata-saver/classes/CustomMetadataSaver.cls
@@ -76,7 +76,13 @@ public inherited sharing class CustomMetadataSaver {
         Metadata.DeployCallback callback = getFlowDeployCallback(customCallbackName, sendEmailOnError, sendEmailOnSuccess);
         System.debug('callback==' + callback);
 
-        return new List<String>{ deploy(consolidatedCustomMetadataRecords, callback) };
+        // TODO need to add an actual Flow to the repo (./extra-tests/ directory probably) to verify Flow functionality works
+        String jobId = deploy(consolidatedCustomMetadataRecords, callback);
+        List<String> flowJobIds = new List<String>();
+        for (Integer i = 0; i < inputs.size(); i++) {
+            flowJobIds.add(jobId);
+        }
+        return flowJobIds;
     }
 
     public static String deploy(List<SObject> customMetadataRecords) {


### PR DESCRIPTION
Fixes #11 - previously, the `deploy()` method used by Flow was returning a list that only contained 1 value (the deployment job ID). This results in the error "The number of results does not match the number of interviews that were executed in a single bulk execution request" - I've updated the code so that the returned list has the same number of outputs as the provided list of inputs.